### PR TITLE
Updated action runner_type to python-script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,6 @@
+# Change Log
+
+# 0.4.0
+
+- Updated action `runner_type` from `run-python` to `python-script`
+

--- a/actions/lockdown_winrm.yaml
+++ b/actions/lockdown_winrm.yaml
@@ -1,6 +1,6 @@
 ---
   name: "lockdown_winrm"
-  runner_type: "run-python"
+  runner_type: "python-script"
   description: "Disable remote WinRM access via RPC"
   enabled: true
   entry_point: "lockdown_winrm.py"

--- a/actions/setup_winrm.yaml
+++ b/actions/setup_winrm.yaml
@@ -1,6 +1,6 @@
 ---
   name: "setup_winrm"
-  runner_type: "run-python"
+  runner_type: "python-script"
   description: "Enable remote WinRM access via RPC, to allow untrusted connections"
   enabled: true
   entry_point: "setup_winrm.py"

--- a/actions/try_winrm.yaml
+++ b/actions/try_winrm.yaml
@@ -1,6 +1,6 @@
 ---
   name: "try_winrm"
-  runner_type: "run-python"
+  runner_type: "python-script"
   description: "Run a basic check to see if WinRM is responding"
   enabled: true
   entry_point: "try_winrm.py"

--- a/actions/winexe_cmd.yaml
+++ b/actions/winexe_cmd.yaml
@@ -1,6 +1,6 @@
 ---
   name: "winexe_cmd"
-  runner_type: "run-python"
+  runner_type: "python-script"
   description: "Run a command via WinEXE (samba/RPC)"
   enabled: true
   entry_point: "winexe_cmd.py"

--- a/actions/winrm_cmd.yaml
+++ b/actions/winrm_cmd.yaml
@@ -1,6 +1,6 @@
 ---
   name: "winrm_cmd"
-  runner_type: "run-python"
+  runner_type: "python-script"
   description: "Run a command via WinRM"
   enabled: true
   entry_point: "winrm_cmd.py"

--- a/actions/wmi_query.yaml
+++ b/actions/wmi_query.yaml
@@ -1,6 +1,6 @@
 ---
   name: "wmi_query"
-  runner_type: "run-python"
+  runner_type: "python-script"
   description: "Run a WMI query on a particular Windows host."
   enabled: true
   entry_point: "wmi_query.py"

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,6 +7,6 @@ keywords:
   - wmi
   - windows management interface
   - wql
-version : 0.3.0
+version : 0.4.0
 author : StackStorm, Inc.
 email : info@stackstorm.com


### PR DESCRIPTION
Updated action `runner_type` from `run-python` to `python-script` based on the following issue: https://github.com/StackStorm/st2/issues/3389 .

Also, updated README.md with a note on running `st2ctl reload --register-configs` when performing config modifications.