### PR TITLE
New action wait_for_winrm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
 lib64/
 parts/
 sdist/

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+# 0.5.0
+
+- Added new action `windows.wait_for_winrm` similar to the `linux.wait_for_ssh` action.
+
+  Contributed by Nick Maludy (Encore Technologies)
+
 # 0.4.0
 
 - Updated action `runner_type` from `run-python` to `python-script`

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,3 @@
+## Pack Contributors
+* StackStorm info@stackstorm.com
+* Encore Technologies code@encore.tech

--- a/README.md
+++ b/README.md
@@ -66,3 +66,29 @@ The WinRM commands require WinRM to be configured to allow non-domain joined con
 the lockdown action.
 
 For more examples, see [WMI Query Language by Example](http://www.codeproject.com/Articles/46390/WMI-Query-Language-by-Example).
+
+### wait_for_winrm
+
+This action behaves similar to the core `linux.wait_for_ssh` action. It allows a workflow
+to wait for a WinRM connection to become available on a Windows host.
+
+
+#### Common parameters
+
+* `host` - Hostname / IP address to connect to
+* `username` - Username used to authenticate.
+* `password` - Password used to authenticate.
+* `verify_ssl_cert` - Should SSL certs on the remote host be validated?
+* `winrm_timeout` - Timeout of each connection attempt (seconds).
+* `sleep_delay` - Time to sleep between connection attempts (seconds).
+* `retries` - Maximum number of retries before failing.
+* `timeout` - Total timeout for the action
+      Note: timeout needs to be `>= ((winrm_timeout + sleep_delay) * retries)` so we override a
+      default Python runner action timeout with a larger value
+
+
+#### Example
+
+``` shell
+st2 run windows.wait_for_winrm host="hostname.domain.tld" username="user@domain.tld" password="xxx" verify_ssl_cert=false
+```

--- a/actions/lib/wait_for_winrm.py
+++ b/actions/lib/wait_for_winrm.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+
+import time
+
+from st2common.runners.base_action import Action
+from winrm import Session
+
+WINRM_HTTP_PORT = 5985
+
+
+class BaseAction(Action):
+    def run(self, host, port, username, password, transport, scheme, verify_ssl_cert,
+            winrm_timeout, sleep_delay, retries):
+
+        # read_timeout must be > operation_timeout (winrm_timeout)
+        read_timeout = winrm_timeout + 1
+        # if connecting to the HTTP port then we must use "http" as the scheme
+        # in the URL
+        if port == WINRM_HTTP_PORT:
+            scheme = "http"
+
+        # construct the URL for connecting to WinRM on the host
+        winrm_url = "{}://{}:{}/wsman".format(scheme, host, port)
+
+        # convert boolean into text required by winrm library
+        server_cert_validation = "validate" if verify_ssl_cert else "ignore"
+
+        # create our session object, this doesn't actually connect
+        # it just sets up all of the information into a reusable object
+        session = Session(winrm_url,
+                          auth=(username, password),
+                          transport=transport,
+                          server_cert_validation=server_cert_validation,
+                          operation_timeout_sec=winrm_timeout,
+                          read_timeout_sec=read_timeout)
+
+        # loop for the given number of retries
+        for index in range(retries):
+            attempt = index + 1
+            shell_id = None
+            try:
+                self.logger.debug('WinRM connection attempt: %s' % (attempt))
+                # openning up a shell is how WinRM connects, this way we do not
+                # need to invoke a command and incur that overhead
+                shell_id = session.protocol.open_shell()
+                return True
+            except Exception as e:
+                self.logger.info('Attempt %s failed (%s), sleeping for %s seconds...' %
+                                 (attempt, str(e), sleep_delay))
+                time.sleep(sleep_delay)
+            finally:
+                if shell_id:
+                    session.protocol.close_shell(shell_id)
+
+        raise Exception('Exceeded max retries (%s)' % (retries))

--- a/actions/wait_for_winrm.yaml
+++ b/actions/wait_for_winrm.yaml
@@ -1,0 +1,72 @@
+---
+name: "wait_for_winrm"
+runner_type: "python-script"
+description: "Action which waits for a WinRM server to become accessible."
+enabled: true
+entry_point: "lib/wait_for_winrm.py"
+parameters:
+  host:
+    description: "Remote hostname/ipaddress."
+    type: "string"
+    required: true
+  port:
+    description: "Remote SSH port."
+    type: "integer"
+    required: true
+    default: 5986
+  username:
+    description: "Username used to authenticate."
+    required: true
+    default: "stanley"
+    type: "string"
+  password:
+    description: "Password used to authenticate."
+    required: true
+    type: "string"
+    secret: true
+  transport:
+    default: "ntlm"
+    description: >
+      The type of transport that WinRM will use to communicate.
+      See https://github.com/diyan/pywinrm#valid-transport-options
+    required: false
+    type: string
+    enum:
+      - "basic"
+      - "certificate"
+      - "credssp"
+      - "kerberos"
+      - "ntlm"
+      - "plaintext"
+      - "ssl"
+  scheme:
+    default: "https"
+    description: 'Scheme to use in the WinRM URL. If using scheme "http" port must be 5985'
+    required: false
+    type: string
+  verify_ssl_cert:
+    default: true
+    description: >
+      Certificate for HTTPS request is verified by default using requests
+      CA bundle which comes from Mozilla. Verification using a custom CA bundle
+      is not yet supported. Set to False to skip verification.
+    type: boolean
+  winrm_timeout:
+    description: "WinRM connection connect timeout (in seconds). This is the timeout of a single connection attempt."
+    type: "integer"
+    default: 5
+  sleep_delay:
+    description: "How long to sleep / wait (in seconds) after each failed connection attempt."
+    type: "integer"
+    default: 20
+  retries:
+    description: "Maximum number of retries."
+    type: "integer"
+    default: 10
+  timeout:
+    default: 400
+    type: "integer"
+    description: >
+      Total timeout for this action.
+      Note: timeout needs to be >= ((winrm_timeout + sleep_delay) * retries) so we override a
+      default Python runner action timeout with a larger value

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,6 +7,6 @@ keywords:
   - wmi
   - windows management interface
   - wql
-version: 0.4.1
+version: 0.5.0
 author : StackStorm, Inc.
 email : info@stackstorm.com


### PR DESCRIPTION
Added a new action `wait_for_winrm` that is analogous to the `linux.wait_for_ssh` action. 

This will allow workflows to pause until the host is available and can start accepting commands.